### PR TITLE
Allow post types to be filterable

### DIFF
--- a/admin-column-view.php
+++ b/admin-column-view.php
@@ -36,8 +36,6 @@ class CF_Admin_Column_View {
 		// Allow post types to be filterable
 		$post_types = apply_filters( 'cf_admin_column_post_types', $post_types);
 
-		var_dump($post_types);
-
 		$menu_label = _x('Column View', 'name in menu', 'cf-admin-column-view');
 
 		foreach ($post_types as $post_type => $post_type_obj) {

--- a/admin-column-view.php
+++ b/admin-column-view.php
@@ -33,6 +33,11 @@ class CF_Admin_Column_View {
 			'show_ui' => true,
 		), 'objects');
 
+		// Allow post types to be filterable
+		$post_types = apply_filters( 'cf_admin_column_post_types', $post_types);
+
+		var_dump($post_types);
+
 		$menu_label = _x('Column View', 'name in menu', 'cf-admin-column-view');
 
 		foreach ($post_types as $post_type => $post_type_obj) {


### PR DESCRIPTION
Usage:

``` php
function remove_post_types_admin_column_view($post_types) {

    unset($post_types['post-type']);

    return $post_types;
}

add_filter('cf_admin_column_post_types', 'remove_post_types_admin_column_view');
```
